### PR TITLE
Added basic Keras support; fixes "None" gradient issue

### DIFF
--- a/tuner_utils/yellowfin.py
+++ b/tuner_utils/yellowfin.py
@@ -201,7 +201,7 @@ class YFOptimizer(object):
 
 
   def apply_gradients(self, grads_tvars, global_step=None):
-    self._grads, self._tvars = zip(*grads_tvars)
+    self._grads, self._tvars = zip(*[(g,t) for g,t in grads_tvars if g is not None])
 
     with tf.variable_scope("apply_updates"):
       if self._clip_thresh_var is not None:

--- a/tuner_utils/yellowfin.py
+++ b/tuner_utils/yellowfin.py
@@ -235,7 +235,8 @@ class YFOptimizer(object):
                                              aggregation_method=aggregation_method,
                                              colocate_gradients_with_ops=colocate_gradients_with_ops,
                                              grad_loss=grad_loss)
-  
+ 
+
   def minimize(self, loss, global_step=None, var_list=None,
                gate_gradients=GATE_OP, aggregation_method=None,
                colocate_gradients_with_ops=False, name=None,
@@ -264,5 +265,3 @@ class YFOptimizer(object):
       print("v ", v)
 
     return self.apply_gradients(grads_and_vars)
-
-        

--- a/tuner_utils/yellowfin.py
+++ b/tuner_utils/yellowfin.py
@@ -137,6 +137,7 @@ class YFOptimizer(object):
     self._grad_squared = []
     self._grad_norm_squared = []
     for v, g in zip(self._tvars, self._grads):
+      if g is None: continue
       with ops.colocate_with(v):
         self._grad_squared.append(tf.square(g) )
     self._grad_norm_squared = [tf.reduce_sum(grad_squared) for grad_squared in self._grad_squared]

--- a/tuner_utils/yellowfin.py
+++ b/tuner_utils/yellowfin.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import numpy as np
 from math import ceil, floor
 import tensorflow as tf
@@ -198,7 +200,7 @@ class YFOptimizer(object):
     return assign_hyper_op
 
 
-  def apply_gradients(self, grads_tvars):
+  def apply_gradients(self, grads_tvars, global_step=None):
     self._grads, self._tvars = zip(*grads_tvars)
 
     with tf.variable_scope("apply_updates"):
@@ -224,6 +226,15 @@ class YFOptimizer(object):
     return tf.group(apply_grad_op, after_apply_op, update_hyper_op, self._increment_global_step_op)
 
 
+  def compute_gradients(self, loss, var_list, global_step=None,
+                        gate_gradients=GATE_OP, aggregation_method=None,
+                        colocate_gradients_with_ops=False, name=None,
+                        grad_loss=None):
+    return self._optimizer.compute_gradients(loss, var_list=var_list, gate_gradients=gate_gradients,
+                                             aggregation_method=aggregation_method,
+                                             colocate_gradients_with_ops=colocate_gradients_with_ops,
+                                             grad_loss=grad_loss)
+  
   def minimize(self, loss, global_step=None, var_list=None,
                gate_gradients=GATE_OP, aggregation_method=None,
                colocate_gradients_with_ops=False, name=None,
@@ -248,8 +259,8 @@ class YFOptimizer(object):
           " that do not support gradients, between variables %s and loss %s." %
           ([str(v) for _, v in grads_and_vars], loss))
     for g, v in grads_and_vars:
-      print "g ", g
-      print "v ", v
+      print("g ", g)
+      print("v ", v)
 
     return self.apply_gradients(grads_and_vars)
 


### PR DESCRIPTION
This PR...

1. Adds support for "compute gradients," which is needed by keras. To use the YFOptimizer in keras, you can do something like... `model.compile(loss='mse', opt=TFOptimizer(YFOptimizer()))`
2. Adds some checks for "None" gradients, which occur in some tf models

Some concerns I still have...

1. the global_step parameter in apply_gradients. This is a named argument passed by keras to optimizers to help them keep track of the global step count. However, YFOptimizer seems to track this itself. I am not exactly sure how these two should interplay for keras models. 
2. I am not 100% sure that this integration is perfect. It runs and for all of the keras demos I tried (conv nets, basic fully-connected nets, etc.), decreases the loss reasonably when compared to adam. However, there are some warning messages printed that I am unsure of. Also, there may be some theoretical issue with global_step, etc.